### PR TITLE
Fix running Super Mario when built with GCC 11

### DIFF
--- a/src/CFG.cpp
+++ b/src/CFG.cpp
@@ -13,11 +13,11 @@ CCFG::~CCFG(void) {
 int CCFG::GAME_HEIGHT = 448;
 int CCFG::GAME_WIDTH = 800;
 
-Text* CCFG::oText = new Text();
-CIMG* CCFG::tSMBLOGO = new CIMG();
+Text* CCFG::oText = NULL;
+CIMG* CCFG::tSMBLOGO = NULL;
 
-MenuManager* CCFG::oMM = new MenuManager();
-Music* CCFG::oMusic = new Music();
+MenuManager* CCFG::oMM = NULL;
+Music* CCFG::oMusic = NULL;
 
 bool CCFG::keySpace = false;
 int CCFG::keyIDA = 0;
@@ -29,18 +29,26 @@ int CCFG::keyIDShift = 0;
 bool CCFG::canMoveBackward = true;
 
 Text* CCFG::getText() {
+	if (!oText)
+		oText = new Text();
 	return oText;
 }
 
 MenuManager* CCFG::getMM() {
+	if (!oMM)
+		oMM = new MenuManager();
 	return oMM;
 }
 
 Music* CCFG::getMusic() {
+	if (!oMusic)
+		oMusic = new Music();
 	return oMusic;
 }
 
 CIMG* CCFG::getSMBLOGO() {
+	if (!tSMBLOGO)
+		tSMBLOGO = new CIMG();
 	return tSMBLOGO;
 }
 


### PR DESCRIPTION
Super Mario crashes when built with GCC 11. It seems that GCC re-orders the static initializers in a way that break assumptions made in `Music::Music`. Here's the stack trace I got:

```
CrashDaemon(15): New coredump file: /tmp/coredump/uMario_27_1619674230
CrashDaemon(15): --- Backtrace for thread #0 (TID 27) ---
CrashDaemon(15): 0x6b2360a8: [/opt/Super_Mario/uMario] Music::Music() +0x50
CrashDaemon(15): 0x6b1bd4e6: [/opt/Super_Mario/uMario] __static_initialization_and_destruction_0(int, int) +0xb6
CrashDaemon(15): 0x6b1bd594: [/opt/Super_Mario/uMario] _GLOBAL__sub_I__ZN4CCFGC2Ev +0x1f```
```

This PR changes how those singletons are initialized.